### PR TITLE
Ensure SUDO_USER a member of the libvirt group

### DIFF
--- a/kube-setup.sh
+++ b/kube-setup.sh
@@ -31,5 +31,15 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/miniku
 chmod +x minikube
 mv minikube /usr/local/bin
 
+#Addd SUDO_USER to libvirt group so that can so that the minikube start command will work after reboot
+if [ -z "$SUDO_USER" ] 
+then
+	echo "Did you log in a root?  please add a non-root user to the libvirt group.  EX:  usermod -a -G libvirt UserID"
+else
+	echo "Adding $SUDO_USER to libvirt group."
+  usermod -a -G libvirt $SUDO_USER
+fi
+
+
 echo at this point, reboot your Fedora Workstation. After reboot, manually run as non-root
 echo minikube start --memory 4096 --vm-driver=kvm2


### PR DESCRIPTION
so that the minikube start command works (with this current setup fo tube-start.sh)

when user not in the group, after rebooting and running the minikube start command, they will receive the following message:
'kvm2' driver reported an issue: /usr/bin/virsh domcapabilities --virttype kvm failed:
error: failed to connect to the hypervisor
error: authentication unavailable: no polkit agent available to authenticate action 'org.libvirt.unix.manage'

IF this occurs, the only way to resolve is minikube delete, and to add the suer to the libvirt group command before trying again.