### PR TITLE
Update image version for sfs.yaml

### DIFF
--- a/sfs.yaml
+++ b/sfs.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: k8s.gcr.io/nginx-slim:0.27
         ports:
         - containerPort: 80
           name: web


### PR DESCRIPTION
The image used in sfs.yaml("k8s.gcr.io/nginx-slim:0.8") leads the following error: 
```
"Failed to pull image "k8s.gcr.io/nginx-slim:0.8": [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of k8s.gcr.io/nginx-slim:0.9 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/". 
```

Using the latest version "k8s.gcr.io/nginx-slim:0.27" fixes this problem.