### PR TITLE
Fixing canary lab

### DIFF
--- a/canary.yaml
+++ b/canary.yaml
@@ -3,20 +3,20 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    app: old
+    app: new
     type: canary
-  name: old
+  name: new-nginx
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: old
+      app: new
   strategy: {}
   template:
     metadata:
       creationTimestamp: null
       labels:
-        app: old
+        app: new
         type: canary
     spec:
       containers:
@@ -29,5 +29,5 @@ spec:
       volumes:
       - name: configfile
         configMap:
-          name: old
+          name: canary
 status: {}


### PR DESCRIPTION
Hi Sander,
while going through your lab "Using Canary Deployments" within the [O'Reilly playlist](https://learning.oreilly.com/playlists/ea6ea0fc-d8e2-422c-94dd-a0a8f608d224/), I noticed that the new deployment yaml has some wrong label and selectors. 

The old deployment is in ckad/old-nginx.yaml (step 2)
and the new deployment is in ckad/canary.yaml (step 6)

Also the configMap created in step 5 is called "canary" and not "old"


Thanks for creating these labs!